### PR TITLE
[vbcc] Use 'cc', not 'gcc'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 # used to create vbcc, vc and ucpp
-CC = gcc -std=c9x -g -DHAVE_AOS4 #-fsanitize=address #-DHAVE_ECPP -DHAVE_MISRA 
+CC = cc -std=c9x -g -DHAVE_AOS4 #-fsanitize=address #-DHAVE_ECPP -DHAVE_MISRA 
 LDFLAGS = -lm
 
 # native version; used to create dtgen


### PR DESCRIPTION
using gcc breaks on BSD systems without a gcc binary.
Some (eg FreeBSD) will use llvm and cc, and NOT have gcc as an
alias.

I've tested this, it still builds fine!